### PR TITLE
fix: removes -d which is not valid for deluge-web

### DIFF
--- a/templates/deluge-web.service.j2
+++ b/templates/deluge-web.service.j2
@@ -9,9 +9,9 @@ Type=simple
 UMask=027
 
 {% if enable_logging == true %}
-ExecStart=/usr/bin/deluge-web -d -c {{ deluge_config_dir }} -l {{ deluge_log_dir }}web.log -L {{ deluge_log_level }}
+ExecStart=/usr/bin/deluge-web -c {{ deluge_config_dir }} -l {{ deluge_log_dir }}web.log -L {{ deluge_log_level }}
 {% else %}
-ExecStart=/usr/bin/deluge-web -d -c {{ deluge_config_dir }}
+ExecStart=/usr/bin/deluge-web -c {{ deluge_config_dir }}
 {% endif %}
 
 Restart=on-failure


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
Resolves an issue where deluge web wouldn't start due to an incorrect argument `-d`

## Related issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!--- Please link to the issue here. -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What additions does it bring? -->
fixes failing service

## How has this been tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of the tests you ran. -->
tested in my lab

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring.
- [x] Non-breaking change (fix or feature that wouldn't cause existing functionality to change/break).
- [ ] Breaking change (fix or feature that would cause existing functionality to change/break).

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes don't generate new warnings.
- [x] I have read the [CONTRIBUTING](https://github.com/totaldebug/.github/blob/master/docs/CONTRIBUTING.md) document.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests pass.
