### PR TITLE
fix: added daemon reload when enabling deluge service

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: restart deluged
-  systemd:
+  ansible.builtin.systemd:
     name: deluged
     state: restarted
   become: true
 
 - name: restart deluge-web
-  systemd:
+  ansible.builtin.systemd:
     name: deluge-web
     state: restarted
   become: true

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Check for config dir
-  stat:
+  ansible.builtin.stat:
     path: "{{ deluge_config_dir | dirname }}"
   register: _deluge_config_dir
   tags:
@@ -9,7 +9,7 @@
     - deluge_config
 
 - name: Create config directory
-  file:
+  ansible.builtin.file:
     path: "{{ deluge_config_dir }}"
     state: directory
     mode: 0700
@@ -24,7 +24,7 @@
   become: true
 
 - name: Checking if we should template the deluge config file
-  template:
+  ansible.builtin.template:
     src: "{{ deluge_core_conf_template }}"
     dest: "{{ deluge_config_dir }}/core.conf"
     owner: "{{ deluge_service_user }}"
@@ -37,7 +37,7 @@
     - deluge_config
 
 - name: deluged config file needs updating. deluge should be stopped beforehand
-  service:
+  ansible.builtin.service:
     name: deluged
     state: stopped
   become: true
@@ -46,7 +46,7 @@
     - deluge_config
 
 - name: Copy deluge configuration file
-  template:
+  ansible.builtin.template:
     src: "{{ deluge_core_conf_template }}"
     dest: "{{ deluge_config_dir }}/core.conf"
     owner: "{{ deluge_service_user }}"
@@ -59,7 +59,7 @@
     - deluge_config
 
 - name: Checking if we should template the deluge-web config file
-  template:
+  ansible.builtin.template:
     src: "{{ deluge_web_conf_template }}"
     dest: "{{ deluge_config_dir }}/web.conf"
     owner: "{{ deluge_service_user }}"
@@ -73,7 +73,7 @@
     - deluge_config
 
 - name: deluge-web config file needs updating. deluge-web should be stopped beforehand
-  service:
+  ansible.builtin.service:
     name: deluge-web
     state: stopped
   become: true
@@ -83,7 +83,7 @@
     - deluge_config
 
 - name: Copy deluge-web configuration file
-  template:
+  ansible.builtin.template:
     src: "{{ deluge_web_conf_template }}"
     dest: "{{ deluge_config_dir }}/web.conf"
     owner: "{{ deluge_service_user }}"

--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -31,7 +31,7 @@
     - deluge
 
 - name: Install Deluge Daemon
-  apt:
+  ansible.builtin.apt:
     name: ['deluged', 'deluge-console']
     update_cache: true
     state: present
@@ -41,7 +41,7 @@
     - deluge
 
 - name: Install Deluge Web
-  apt:
+  ansible.builtin.apt:
     name: deluge-web
     update_cache: true
     state: present

--- a/tasks/install/main.yml
+++ b/tasks/install/main.yml
@@ -4,29 +4,29 @@
   include: "{{ ansible_os_family }}.yml"
 
 - name: create deluge group
-  group:
+  ansible.builtin.group:
     name: "{{ deluge_service_group }}"
     state: present
   become: true
   become_user: root
 
 - name: Get all users from device
-  getent:
+  ansible.builtin.getent:
     database: passwd
     key:
 
 - name: set fact when user exists
-  set_fact:
+  ansible.builtin.set_fact:
     user_exists: true
   when: deluge_service_user in ansible_facts.getent_passwd
 
 - name: set fact when user does not exists
-  set_fact:
+  ansible.builtin.set_fact:
     user_exists: false
   when: deluge_service_user not in ansible_facts.getent_passwd
 
 - name: Create deluge user
-  user:
+  ansible.builtin.user:
     name: "{{ deluge_service_user }}"
     group: "{{ deluge_service_group }}"
     comment: "Deluge Service"
@@ -39,14 +39,14 @@
   become_user: root
 
 - name: Check for Log dir
-  stat:
+  ansible.builtin.stat:
     path: "{{ deluge_log_dir | dirname }}"
   register: _deluge_log_dir
   tags:
     - deluge
 
 - name: Create logging directory
-  file:
+  ansible.builtin.file:
     path: "{{ deluge_log_dir }}"
     state: directory
     mode: '0750'
@@ -60,14 +60,14 @@
   become: true
 
 - name: Check for Download dir
-  stat:
+  ansible.builtin.stat:
     path: "{{ deluge_download_location | dirname }}"
   register: _deluge_download_location
   tags:
     - deluge
 
 - name: Deluge download directory should be created
-  file:
+  ansible.builtin.file:
     path: "{{ deluge_download_location }}"
     owner: "{{ deluge_service_user }}"
     group: "{{ deluge_service_group }}"

--- a/tasks/install/systemd.yml
+++ b/tasks/install/systemd.yml
@@ -1,14 +1,14 @@
 ---
 
 - name: Check for deluged user service dir
-  stat:
+  ansible.builtin.stat:
     path: "{{ deluge_user_service_dir | dirname }}"
   register: _deluge_user_service_dir
   tags:
     - deluge
 
 - name: Create deluged user service dir
-  file:
+  ansible.builtin.file:
     path: "{{ deluge_user_service_dir }}"
     state: directory
     mode: '0750'
@@ -22,7 +22,7 @@
   become: true
 
 - name: Copy user service config
-  template:
+  ansible.builtin.template:
     src: "user.conf.j2"
     dest: "{{ deluge_user_service_dir }}user.conf"
     owner: root
@@ -31,7 +31,7 @@
   become: true
 
 - name: Check for deluge-web user service dir
-  stat:
+  ansible.builtin.stat:
     path: "{{ deluge_web_user_service_dir | dirname }}"
   register: _deluge_web_user_service_dir
   when: deluge_web
@@ -39,7 +39,7 @@
     - deluge
 
 - name: Create deluge-web user service dir
-  file:
+  ansible.builtin.file:
     path: "{{ deluge_web_user_service_dir }}"
     state: directory
     mode: '0750'
@@ -54,7 +54,7 @@
   become: true
 
 - name: Copy user service config
-  template:
+  ansible.builtin.template:
     src: "user.conf.j2"
     dest: "{{ deluge_web_user_service_dir }}user.conf"
     owner: root
@@ -66,7 +66,7 @@
     - deluge
 
 - name: Install deluged services
-  template:
+  ansible.builtin.template:
     src: "deluged.service.j2"
     dest: "/etc/systemd/system/deluged.service"
     owner: root
@@ -77,7 +77,7 @@
     - deluge
 
 - name: Install deluge-web services
-  template:
+  ansible.builtin.template:
     src: "deluge-web.service.j2"
     dest: "/etc/systemd/system/deluge-web.service"
     owner: root
@@ -87,15 +87,16 @@
   tags:
     - deluge
 
-- name: enable and start Deluged service
-  systemd:
+- name: Reload Daemon, and enable Deluged service
+  ansible.builtin.systemd:
     name: deluged
     enabled: true
+    daemon_reload: true
   become: true
   changed_when: false
 
-- name: enable and start Deluge services
-  systemd:
+- name: Enable Deluge Web service
+  ansible.builtin.systemd:
     name: deluge-web
     enabled: true
   become: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
Adds a daemon reload when the deluge service is enabled. 
Also updated to full module paths

## Related issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!--- Please link to the issue here. -->
fixes #5 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What additions does it bring? -->
Resolves an issue with `systemctl deamon` not reloading.

## How has this been tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of the tests you ran. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring.
- [x] Non-breaking change (fix or feature that wouldn't cause existing functionality to change/break).
- [ ] Breaking change (fix or feature that would cause existing functionality to change/break).

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes don't generate new warnings.
- [x] I have read the [CONTRIBUTING](https://github.com/totaldebug/.github/blob/master/docs/CONTRIBUTING.md) document.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests pass.
