### PR TITLE
fix: remove un-used option

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -53,11 +53,10 @@ ansible-galaxy install totaldebug.deluge
 |     `deluge_service_user`      |                 `deluge`                 |                         Username for the service account                         |
 |     `deluge_service_group`     |                 `deluge`                 |                          Group for the service account                           |
 |         `deluged_port`         |                 `58846`                  |                                   Deluge port                                    |
-|         `deluge_home`          |            `/ver/log/deluge/`            | Sets the default home for the deluge service account, config will be stored here |
+|         `deluge_home`          |            `/var/lib/deluge`            | Sets the default home for the deluge service account, config will be stored here |
 |   `deluge_download_location`   |      `{{ deluge_home }}/downloads`       |                            Downloaded file directory                             |
 |  `deluge_move_completed_path`  |    `'{{ deluge_download_location }}'`    |                             Completed downloads path                             |
 | `deluge_torrentfiles_location` |    `'{{ deluge_download_location }}'`    |                           Deluge torrent file location                           |
-|   `deluge_autoadd_location`    |    `'{{ deluge_download_location }}'`    |                              Deluge Auto Add folder                              |
 |   `deluge_user_service_dir`    | `/etc/systemd/system/deluged.service.d/` |                  Sets the directory for the user service config                  |
 |  `deluge_core_conf_template`   |              `core.conf.j2`              |        allows the use of a custom config file see custom templates below         |
 |        `deluge_plugins`        |                                          |                add a list of plugins that you want to be enabled                 |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,6 @@ deluge_config_dir: '{{ deluge_home }}/.config/deluge'
 deluge_download_location: '{{ deluge_home }}/downloads'
 deluge_move_completed_path: '{{ deluge_download_location }}'
 deluge_torrentfiles_location: '{{ deluge_download_location }}'
-deluge_autoadd_location: '{{ deluge_download_location }}'
 deluge_user_service_dir: '/etc/systemd/system/deluged.service.d/'
 deluge_core_conf_template: 'core.conf.j2'
 deluge_plugins:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
Removed un-used option `deluge_autoadd_location`

## Related issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!--- Please link to the issue here. -->
fixes #3 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What additions does it bring? -->

## How has this been tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of the tests you ran. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring.
- [x] Non-breaking change (fix or feature that wouldn't cause existing functionality to change/break).
- [ ] Breaking change (fix or feature that would cause existing functionality to change/break).

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes don't generate new warnings.
- [x] I have read the [CONTRIBUTING](https://github.com/totaldebug/.github/blob/master/docs/CONTRIBUTING.md) document.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests pass.
